### PR TITLE
Fix deque initialization error

### DIFF
--- a/Bot-Trading_Swing (1).py
+++ b/Bot-Trading_Swing (1).py
@@ -1,4 +1,4 @@
-﻿# Standard library imports
+# Standard library imports
 print("🚀 [Bot] Starting imports...")
 
 # ==================================================
@@ -12625,7 +12625,7 @@ class PortfolioEnvironment(gym.Env):
         self.action_space = spaces.MultiDiscrete([3] * self.n_symbols)
         # --- K T THC C I money ---
 
-        self.returns_history = deque(maprocessingen=30)
+        self.returns_history = deque(maxlen=30)
         self.reset()
 
     def _get_observation(self):


### PR DESCRIPTION
Fix `TypeError` in `deque()` by changing `maprocessingen` to `maxlen`.

---
<a href="https://cursor.com/background-agent?bcId=bc-22497740-b2d6-43c8-8151-55a5b05e9b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22497740-b2d6-43c8-8151-55a5b05e9b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

